### PR TITLE
Dev - change the jax installation way

### DIFF
--- a/dl-container/GPU/Dockerfile
+++ b/dl-container/GPU/Dockerfile
@@ -78,7 +78,7 @@ RUN pip3 install --no-cache-dir transformers;\
 
 # installing Jax with cuda -- installed aftr torch can install newer version of cuda
 # RUN pip install "jax[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-RUN pip3 install --no-cache-dir --upgrade "jax[cuda12_pip]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+RUN pip3 install --no-cache-dir --upgrade "jax[cuda12_local]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
 # fix the ldconfig promblem
 RUN mv /usr/local/lib/libtbbmalloc_proxy.so.2 /usr/local/lib/libtbbmalloc_proxy.so.2.real ;\

--- a/dl-container/GPU/Dockerfile
+++ b/dl-container/GPU/Dockerfile
@@ -1,4 +1,4 @@
-ARG TF_VER="2.16.0rc0"
+ARG TF_VER="2.16.1"
 
 #FROM gcr.io/tensorflow/tensorflow:latest-gpu
 # FROM tensorflow/tensorflow:latest-gpu-py3


### PR DESCRIPTION
Using the pip-install for cuda will cause the error due to new jax using cuda12.4 while tensorflow using 12.3. 
to make the tf, jax, and torch using the same version of cuda, the installation of jax is used to "local" mode.