### PR TITLE
using nv tensorflow

### DIFF
--- a/dl-container/GPU/Dockerfile
+++ b/dl-container/GPU/Dockerfile
@@ -1,4 +1,5 @@
 ARG TF_VER="2.18.0"
+ARG NV_VER="24.12-tf2-py3"
 
 #FROM gcr.io/tensorflow/tensorflow:latest-gpu
 # FROM tensorflow/tensorflow:latest-gpu-py3
@@ -9,7 +10,8 @@ ARG TF_VER="2.18.0"
 # FROM tensorflow/tensorflow:2.15.0-gpu #2.15 cannot use cuda#2.15 cannot use cuda
 # FROM tensorflow/tensorflow:2.12.0-gpu # the pallalle dataloader can work with this version
 
-FROM tensorflow/tensorflow:${TF_VER}-gpu
+# FROM tensorflow/tensorflow:${TF_VER}-gpu
+FROM nvcr.io/nvidia/tensorflow:${NV_VER}
 
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -89,7 +91,7 @@ RUN pip3 install --no-cache-dir transformers;\
 # RUN pip3 install --no-cache-dir --upgrade "jax[cuda12_local]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
 ## installing jax directly from pip
-RUN pip install "jax[cuda12]"
+RUN pip install -U "jax[cuda12]"
 
 # # fix the ldconfig promblem
 # RUN mv /usr/local/lib/libtbbmalloc_proxy.so.2 /usr/local/lib/libtbbmalloc_proxy.so.2.real ;\
@@ -143,7 +145,7 @@ RUN mkdir /root/.ssh ;\
     chmod 644 /root/.ssh/authorized_keys ;\
     echo ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDKgLR7W2eqrB3SOKbKr5wom8ZmhAPKwXiCd+H+9GKeG1uxCYPJbRoMXBG+8ot/pyyk7ObVpJvTxkPYhKkc1j2LGsgJ2O8AMo1t0PYGn0Lr5UdnxwnBjuxOZk9cRXAlfhVQkYLwRP+47+JYEHUUiuAKxxmfiuEVag8yrpw9BrB86XdR7bTqw8bAn8h1t1LYmAEc/Bh9GAWQuu7TDO0d6ymM1uygioYQrvy76mmK4zlbuVXqTLUUF5TjmJvZHjbjMDUvnr8P5DELo23VWBSP64CRLDSD3Q0l1l+X7zwuIc5H99aDg/x8txzfynjrP1P2Ae4sZBLLnaKDtZF2zaiTOJm08eFQ5x/xEByR8Lo2K590DwhGBARQStLbXtjb4B5rS9CmkE0+DWX6Mg9yrmmQmFWCNo3NTYn7xx/S56E5IYJlXdFbIO8BfAoNaLx2LdJldUklKctPyAEvtIDMCuEwVZTYwXJT7AFZ1KClp0nbP3dl20PkYQRzivWyA38SaSu7fg0= markliou@markliou-ZBPDuo >> /root/.ssh/authorized_keys
 
-RUN mkdir /workspace
+# RUN mkdir /workspace
 WORKDIR /workspace
 
 # IPython


### PR DESCRIPTION
## Summary by Sourcery

Update the Dockerfile to use the NVIDIA TensorFlow image and upgrade JAX.

Build:
- Use the `nvcr.io/nvidia/tensorflow` image instead of the official TensorFlow image.
- Upgrade JAX to the latest version.