### PR TITLE
Dev

### DIFF
--- a/dl-container/GPU/Dockerfile
+++ b/dl-container/GPU/Dockerfile
@@ -1,5 +1,5 @@
-# ARG TF_VER="2.18.0"nightly-gpu
-ARG TF_VER="nightly"
+ARG TF_VER="2.18.0"
+# ARG TF_VER="nightly"
 ARG NV_VER="24.12-tf2-py3"
 
 #FROM gcr.io/tensorflow/tensorflow:latest-gpu

--- a/dl-container/GPU/Dockerfile
+++ b/dl-container/GPU/Dockerfile
@@ -93,7 +93,7 @@ RUN pip3 install --no-cache-dir transformers;\
 # RUN pip3 install --no-cache-dir --upgrade "jax[cuda12_local]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
 ## installing jax directly from pip
-RUN pip install -U "jax[cuda12_local]"
+RUN pip install -U "jax[cuda12]"
 
 # # fix the ldconfig promblem
 # RUN mv /usr/local/lib/libtbbmalloc_proxy.so.2 /usr/local/lib/libtbbmalloc_proxy.so.2.real ;\

--- a/dl-container/GPU/Dockerfile
+++ b/dl-container/GPU/Dockerfile
@@ -1,5 +1,5 @@
-ARG TF_VER="2.18.0"
-# ARG TF_VER="nightly"
+# ARG TF_VER="2.18.0"
+ARG TF_VER="nightly"
 ARG NV_VER="25.01-tf2-py3"
 
 #FROM gcr.io/tensorflow/tensorflow:latest-gpu
@@ -11,8 +11,8 @@ ARG NV_VER="25.01-tf2-py3"
 # FROM tensorflow/tensorflow:2.15.0-gpu #2.15 cannot use cuda#2.15 cannot use cuda
 # FROM tensorflow/tensorflow:2.12.0-gpu # the pallalle dataloader can work with this version
 
-# FROM tensorflow/tensorflow:${TF_VER}-gpu
-FROM nvcr.io/nvidia/tensorflow:${NV_VER}
+FROM tensorflow/tensorflow:${TF_VER}-gpu
+# FROM nvcr.io/nvidia/tensorflow:${NV_VER}
 
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -62,11 +62,11 @@ RUN apt-get update -y;\
     pip3 install redis;\
     pip3 install scikit-image;\
     pip3 install tensorflow-datasets;\
-    pip3 install tensorflow-addons;\
+    # pip3 install tensorflow-addons;\
     pip3 install tensorflow-probability;\
     pip3 install matplotlib;\
     pip3 install dvc;\
-    pip3 install tf-models-nightly ;\
+    # pip3 install tf-models-nightly ;\
     pip3 install opencv-contrib-python
 
 
@@ -93,8 +93,8 @@ RUN pip3 install --no-cache-dir transformers;\
 # RUN pip3 install --no-cache-dir --upgrade "jax[cuda12_local]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
 ## installing jax directly from pip
-# RUN pip install -U "jax[cuda12]"
-RUN pip install -U "jax[cuda12_local]"
+RUN pip install -U "jax[cuda12]"
+# RUN pip install -U "jax[cuda12_local]"
 
 # # fix the ldconfig promblem
 # RUN mv /usr/local/lib/libtbbmalloc_proxy.so.2 /usr/local/lib/libtbbmalloc_proxy.so.2.real ;\

--- a/dl-container/GPU/Dockerfile
+++ b/dl-container/GPU/Dockerfile
@@ -93,7 +93,7 @@ RUN pip3 install --no-cache-dir transformers;\
 # RUN pip3 install --no-cache-dir --upgrade "jax[cuda12_local]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
 ## installing jax directly from pip
-RUN pip install -U "jax[cuda12]"
+RUN pip install -U "jax[cuda12_local]"
 
 # # fix the ldconfig promblem
 # RUN mv /usr/local/lib/libtbbmalloc_proxy.so.2 /usr/local/lib/libtbbmalloc_proxy.so.2.real ;\

--- a/dl-container/GPU/Dockerfile
+++ b/dl-container/GPU/Dockerfile
@@ -1,6 +1,6 @@
 ARG TF_VER="2.18.0"
 # ARG TF_VER="nightly"
-ARG NV_VER="24.12-tf2-py3"
+ARG NV_VER="25.01-tf2-py3"
 
 #FROM gcr.io/tensorflow/tensorflow:latest-gpu
 # FROM tensorflow/tensorflow:latest-gpu-py3
@@ -11,8 +11,8 @@ ARG NV_VER="24.12-tf2-py3"
 # FROM tensorflow/tensorflow:2.15.0-gpu #2.15 cannot use cuda#2.15 cannot use cuda
 # FROM tensorflow/tensorflow:2.12.0-gpu # the pallalle dataloader can work with this version
 
-FROM tensorflow/tensorflow:${TF_VER}-gpu
-# FROM nvcr.io/nvidia/tensorflow:${NV_VER}
+# FROM tensorflow/tensorflow:${TF_VER}-gpu
+FROM nvcr.io/nvidia/tensorflow:${NV_VER}
 
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -93,7 +93,8 @@ RUN pip3 install --no-cache-dir transformers;\
 # RUN pip3 install --no-cache-dir --upgrade "jax[cuda12_local]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
 ## installing jax directly from pip
-RUN pip install -U "jax[cuda12]"
+# RUN pip install -U "jax[cuda12]"
+RUN pip install -U "jax[cuda12_local]"
 
 # # fix the ldconfig promblem
 # RUN mv /usr/local/lib/libtbbmalloc_proxy.so.2 /usr/local/lib/libtbbmalloc_proxy.so.2.real ;\


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update the base Docker image to use TensorFlow nightly and NVIDIA driver 25.01. Remove tensorflow-addons and tf-models-nightly dependencies.