### PR TITLE
Dev

### DIFF
--- a/dl-container/GPU/Dockerfile
+++ b/dl-container/GPU/Dockerfile
@@ -41,13 +41,13 @@ RUN apt-get update -y;\
 RUN pip install --upgrade pip
 
 RUN apt-get update -y;\
-    apt install python3-pip -y;\
+    # apt install python3-pip -y;\
     apt install python3-tk -y;\
     apt install git -y;\
     apt install vim -y;\
     apt install wget -y;\
     apt install -y libsm6 libxext6 ;\
-    easy_install pip ;\
+    # easy_install pip ;\
     pip3 install tqdm;\
     pip3 install Pillow;\
     pip3 install scipy;\
@@ -62,7 +62,6 @@ RUN apt-get update -y;\
     pip3 install redis;\
     pip3 install scikit-image;\
     pip3 install tensorflow-datasets;\
-    # pip3 install tensorflow-addons;\
     pip3 install tensorflow-probability;\
     pip3 install matplotlib;\
     pip3 install dvc;\

--- a/dl-container/GPU/Dockerfile
+++ b/dl-container/GPU/Dockerfile
@@ -1,4 +1,4 @@
-ARG TF_VER="2.17.0"
+ARG TF_VER="2.18.0"
 # ARG TF_VER="nightly"
 ARG NV_VER="25.01-tf2-py3"
 
@@ -11,8 +11,8 @@ ARG NV_VER="25.01-tf2-py3"
 # FROM tensorflow/tensorflow:2.15.0-gpu #2.15 cannot use cuda#2.15 cannot use cuda
 # FROM tensorflow/tensorflow:2.12.0-gpu # the pallalle dataloader can work with this version
 
-# FROM tensorflow/tensorflow:${TF_VER}-gpu
-FROM nvcr.io/nvidia/tensorflow:${NV_VER}
+FROM tensorflow/tensorflow:${TF_VER}-gpu
+# FROM nvcr.io/nvidia/tensorflow:${NV_VER}
 
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -92,8 +92,8 @@ RUN pip3 install --no-cache-dir transformers;\
 # RUN pip3 install --no-cache-dir --upgrade "jax[cuda12_local]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
 ## installing jax directly from pip
-# RUN pip install -U "jax[cuda12]"
-RUN pip3 install -U "jax[cuda12_local]"
+RUN pip3 install -U "jax[cuda12]"
+# RUN pip3 install -U "jax[cuda12_local]"
 
 # # fix the ldconfig promblem
 # RUN mv /usr/local/lib/libtbbmalloc_proxy.so.2 /usr/local/lib/libtbbmalloc_proxy.so.2.real ;\

--- a/dl-container/GPU/Dockerfile
+++ b/dl-container/GPU/Dockerfile
@@ -1,5 +1,5 @@
-# ARG TF_VER="2.18.0"
-ARG TF_VER="nightly"
+ARG TF_VER="2.18.0"
+# ARG TF_VER="nightly"
 ARG NV_VER="25.01-tf2-py3"
 
 #FROM gcr.io/tensorflow/tensorflow:latest-gpu

--- a/dl-container/GPU/Dockerfile
+++ b/dl-container/GPU/Dockerfile
@@ -1,4 +1,4 @@
-ARG TF_VER="2.18.0"
+ARG TF_VER="2.17.0"
 # ARG TF_VER="nightly"
 ARG NV_VER="25.01-tf2-py3"
 
@@ -93,8 +93,8 @@ RUN pip3 install --no-cache-dir transformers;\
 # RUN pip3 install --no-cache-dir --upgrade "jax[cuda12_local]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 
 ## installing jax directly from pip
-RUN pip install -U "jax[cuda12]"
-# RUN pip install -U "jax[cuda12_local]"
+# RUN pip install -U "jax[cuda12]"
+RUN pip install -U "jax[cuda12_local]"
 
 # # fix the ldconfig promblem
 # RUN mv /usr/local/lib/libtbbmalloc_proxy.so.2 /usr/local/lib/libtbbmalloc_proxy.so.2.real ;\

--- a/dl-container/GPU/Dockerfile
+++ b/dl-container/GPU/Dockerfile
@@ -11,8 +11,8 @@ ARG NV_VER="25.01-tf2-py3"
 # FROM tensorflow/tensorflow:2.15.0-gpu #2.15 cannot use cuda#2.15 cannot use cuda
 # FROM tensorflow/tensorflow:2.12.0-gpu # the pallalle dataloader can work with this version
 
-FROM tensorflow/tensorflow:${TF_VER}-gpu
-# FROM nvcr.io/nvidia/tensorflow:${NV_VER}
+# FROM tensorflow/tensorflow:${TF_VER}-gpu
+FROM nvcr.io/nvidia/tensorflow:${NV_VER}
 
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/dl-container/GPU/Dockerfile
+++ b/dl-container/GPU/Dockerfile
@@ -94,7 +94,7 @@ RUN pip3 install --no-cache-dir transformers;\
 
 ## installing jax directly from pip
 # RUN pip install -U "jax[cuda12]"
-RUN pip install -U "jax[cuda12_local]"
+RUN pip3 install -U "jax[cuda12_local]"
 
 # # fix the ldconfig promblem
 # RUN mv /usr/local/lib/libtbbmalloc_proxy.so.2 /usr/local/lib/libtbbmalloc_proxy.so.2.real ;\


### PR DESCRIPTION
## Summary by Sourcery

Downgrade TensorFlow to 2.18.0, remove redundant pip installations, and use pip3 for JAX installation.

Build:
- Set TensorFlow version to 2.18.0 instead of nightly.
- Remove unnecessary installation of python3-pip and easy_install pip.
- Install JAX with pip3 instead of pip to ensure consistency with other package installations