### PR TITLE
Dev

### DIFF
--- a/.cache_ggshield
+++ b/.cache_ggshield
@@ -1,0 +1,1 @@
+{"last_found_secrets": [{"match": "be611cb57e458d205e70756087b1bc286e20fec575cd453ebed11e395c7e30ee", "name": "chpasswd Username Password - commit://staged/dl-container/GPU/Dockerfile"}]}

--- a/dl-container/GPU/Dockerfile
+++ b/dl-container/GPU/Dockerfile
@@ -44,6 +44,7 @@ RUN apt-get update -y;\
     apt install wget -y;\
     apt install -y libsm6 libxext6 zlib1g-dev libjpeg-dev;\
     # easy_install pip ;\
+    pip3 install --no-cache-dir ninja ;\
     pip3 install tqdm;\
     # pip3 install Pillow;\
     pip3 install pillow-simd;\
@@ -71,7 +72,7 @@ RUN apt-get update -y;\
 # install torchao for current cuda version
 RUN git clone https://github.com/pytorch/ao.git && \
     cd ao && \
-    TORCH_CUDA_ARCH_LIST="8.0 8.6 8.9 9.0+PTX" python setup.py install && \
+    MAX_JOBS=$(nproc) TORCH_CUDA_ARCH_LIST="8.0 8.6 8.9 9.0 10.0+PTX" python setup.py install && \
     cd .. && \
     rm -fr ao
 

--- a/dl-container/GPU/Dockerfile
+++ b/dl-container/GPU/Dockerfile
@@ -65,7 +65,8 @@ RUN apt-get update -y;\
     pip3 install dvc dvclive;\
     pip3 install virtualenv;\
     # pip3 install tf-models-nightly ;\
-    pip3 install opencv-contrib-python
+    pip3 install opencv-contrib-python ;\
+    pip3 install torchao
 
 
 

--- a/dl-container/GPU/Dockerfile
+++ b/dl-container/GPU/Dockerfile
@@ -65,8 +65,16 @@ RUN apt-get update -y;\
     pip3 install dvc dvclive;\
     pip3 install virtualenv;\
     # pip3 install tf-models-nightly ;\
-    pip3 install opencv-contrib-python ;\
-    pip3 install torchao
+    # pip3 install torchao
+    pip3 install opencv-contrib-python
+
+# install torchao for current cuda version
+RUN git clone https://github.com/pytorch/ao.git && \
+    cd ao && \
+    TORCH_CUDA_ARCH_LIST="8.0 8.6 8.9 9.0+PTX" python setup.py install && \
+    cd .. && \
+    rm -fr ao
+
 
 
 


### PR DESCRIPTION
## Summary by Sourcery

Update the GPU Docker image to include additional build tooling and install torchao from source for the current CUDA configuration.

Build:
- Add ninja Python package to the GPU Docker image for faster native builds.
- Replace the commented torchao pip installation with a source build from the pytorch/ao repository tailored to the target CUDA architectures.
- Add a .cache_ggshield file to the repository, likely for security scanning or caching configuration.