### PR TITLE
[dev] add pr gpu test gate

### DIFF
--- a/.github/workflows/pr_gpu_test.yml
+++ b/.github/workflows/pr_gpu_test.yml
@@ -1,0 +1,34 @@
+name: pr_gpu_test
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - master
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-gpu-test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gpu-image-test:
+    runs-on:
+      - hope
+    env:
+      TEST_IMAGE: dl-container-pr:${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v4
+
+      - name: build GPU image
+        run: docker build --pull -t "$TEST_IMAGE" ./dl-container/GPU
+
+      - name: run GPU smoke test
+        run: docker run --rm --gpus all "$TEST_IMAGE" gpu_test
+
+      - name: cleanup test image
+        if: always()
+        run: docker rmi -f "$TEST_IMAGE" || true

--- a/dl-container/GPU/gpu_test.py
+++ b/dl-container/GPU/gpu_test.py
@@ -1,50 +1,119 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import numpy as np
-# import tensorflow as tf
 import jax
+import jaxlib
 import jax.numpy as jnp
 import torch
 
 
-def check_tf():
-    print("Checking tensorflow gpu available...")
-    assert (len(tf.config.list_physical_devices('GPU')) > 0)
-
-    # test tensorflow
-    sample = np.array([.1, .2, .3])
-    print("Checking tensorflow function ...")
-    tfV = tf.Variable(sample)
-    assert(((tfV * 2).numpy() == sample * 2).all())
+def print_env_info():
+    print("Checking GPU test environment...")
+    print(f"PyTorch version: {torch.__version__}")
+    print(f"PyTorch CUDA version: {torch.version.cuda}")
+    print(f"PyTorch cuDNN version: {torch.backends.cudnn.version()}")
+    print(f"JAX version: {jax.__version__}")
+    print(f"jaxlib version: {jaxlib.__version__}")
+    print(f"JAX default backend: {jax.default_backend()}")
+    print(f"JAX devices: {jax.devices()}")
 
 
 def check_jax():
     print("Checking jax gpu available...")
-    assert (jax.devices()[0].platform != 'cpu')
+    gpu_devices = [
+        device for device in jax.devices() if device.platform in ("gpu", "cuda")
+    ]
+    assert gpu_devices, f"No JAX GPU device found: {jax.devices()}"
+    device = gpu_devices[0]
+    print(f"Using JAX device: {device}")
 
-    # test jax
-    sample = np.array([.1, .2, .3])
-    print("Checking jax function ...")
-    jnpV = jnp.array(sample)
-    assert((np.array(jnpV * 2) == (sample * 2).astype(np.float32)).all())
+    print("Checking JAX GPU tensor function...")
+    sample = np.array([.1, .2, .3], dtype=np.float32)
+    jax_tensor = jax.device_put(jnp.asarray(sample), device)
+    doubled = (jax_tensor * 2).block_until_ready()
+    np.testing.assert_allclose(np.asarray(doubled), sample * 2, rtol=1e-6, atol=1e-6)
+
+    print("Checking JAX jit matmul on GPU...")
+    matrix = (np.arange(1024, dtype=np.float32).reshape(32, 32) / 1024.0)
+    identity = np.eye(32, dtype=np.float32) * 2.0
+
+    @jax.jit
+    def jit_matmul(x, y):
+        return (x @ y) + jnp.float32(1.0)
+
+    jax_matrix = jax.device_put(jnp.asarray(matrix), device)
+    jax_identity = jax.device_put(jnp.asarray(identity), device)
+    result = jit_matmul(jax_matrix, jax_identity).block_until_ready()
+    np.testing.assert_allclose(
+        np.asarray(result),
+        (matrix @ identity) + 1.0,
+        rtol=1e-5,
+        atol=1e-5,
+    )
 
 
 def check_torch():
     print("Checking torch gpu available...")
-    assert (torch.cuda.is_available())
+    assert torch.cuda.is_available(), "No PyTorch CUDA device found"
+    assert torch.cuda.device_count() > 0, "PyTorch reports zero CUDA devices"
+    device = torch.device("cuda:0")
+    print(f"Using PyTorch device: {torch.cuda.get_device_name(device)}")
+    print(f"PyTorch device capability: {torch.cuda.get_device_capability(device)}")
 
-    # test pytorch
-    sample = np.array([.1, .2, .3])
-    print("Checking torch function ...")
-    torchV = torch.FloatTensor(sample)
-    assert(((torchV * 2).numpy() == (sample * 2).astype(np.float32)).all())
+    torch.backends.cuda.matmul.allow_tf32 = False
+    torch.backends.cudnn.allow_tf32 = False
+
+    print("Checking PyTorch GPU tensor function...")
+    sample = np.array([.1, .2, .3], dtype=np.float32)
+    torch_tensor = torch.tensor(sample, dtype=torch.float32, device=device)
+    assert torch_tensor.is_cuda, "PyTorch tensor is not on CUDA"
+    doubled = torch_tensor * 2
+    torch.cuda.synchronize(device)
+    np.testing.assert_allclose(
+        doubled.detach().cpu().numpy(),
+        sample * 2,
+        rtol=1e-6,
+        atol=1e-6,
+    )
+
+    print("Checking PyTorch matmul on GPU...")
+    matrix = torch.arange(1024, dtype=torch.float32, device=device).reshape(32, 32)
+    matrix = matrix / 1024.0
+    identity = torch.eye(32, dtype=torch.float32, device=device) * 2.0
+    result = (matrix @ identity) + 1.0
+    assert result.is_cuda, "PyTorch matmul result is not on CUDA"
+    torch.cuda.synchronize(device)
+    expected = (
+        (np.arange(1024, dtype=np.float32).reshape(32, 32) / 1024.0)
+        @ (np.eye(32, dtype=np.float32) * 2.0)
+    ) + 1.0
+    np.testing.assert_allclose(
+        result.detach().cpu().numpy(),
+        expected,
+        rtol=1e-5,
+        atol=1e-5,
+    )
+
+
+def check_tf():
+    print("Checking tensorflow gpu available...")
+    import tensorflow as tf
+
+    assert len(tf.config.list_physical_devices("GPU")) > 0
+
+    sample = np.array([.1, .2, .3], dtype=np.float32)
+    print("Checking tensorflow function ...")
+    tf_tensor = tf.Variable(sample)
+    np.testing.assert_allclose((tf_tensor * 2).numpy(), sample * 2)
 
 
 
 def main():
+    print_env_info()
     # check_tf()
-    check_jax()
     check_torch()
+    check_jax()
+    print("GPU smoke test passed.")
 
 if __name__ == "__main__":
     main()

--- a/dl-container/GPU/jax_sample_code.py
+++ b/dl-container/GPU/jax_sample_code.py
@@ -1,0 +1,128 @@
+import tensorflow_datasets as tfds  # TFDS to download MNIST.
+import tensorflow as tf  # TensorFlow / `tf.data` operations.
+
+from flax import nnx  # The Flax NNX API.
+from functools import partial
+import optax
+
+#from IPython.display import clear_output
+# import matplotlib.pyplot as plt
+
+
+tf.random.set_seed(0)  # Set the random seed for reproducibility.
+
+train_steps = 5000
+eval_every = 200
+batch_size = 128
+
+train_ds: tf.data.Dataset = tfds.load('mnist', split='train')
+test_ds: tf.data.Dataset = tfds.load('mnist', split='test')
+
+train_ds = train_ds.map(
+  lambda sample: {
+    'image': tf.cast(sample['image'], tf.float32) / 255,
+    'label': sample['label'],
+  }
+)  # normalize train set
+test_ds = test_ds.map(
+  lambda sample: {
+    'image': tf.cast(sample['image'], tf.float32) / 255,
+    'label': sample['label'],
+  }
+)  # Normalize the test set.
+
+# Create a shuffled dataset by allocating a buffer size of 1024 to randomly draw elements from.
+train_ds = train_ds.repeat().shuffle(1024)
+# Group into batches of `batch_size` and skip incomplete batches, prefetch the next sample to improve latency.
+train_ds = train_ds.batch(batch_size, drop_remainder=True).take(train_steps).prefetch(1)
+# Group into batches of `batch_size` and skip incomplete batches, prefetch the next sample to improve latency.
+test_ds = test_ds.batch(batch_size, drop_remainder=True).prefetch(1)
+
+class CNN(nnx.Module):
+  """A simple CNN model."""
+
+  def __init__(self, *, rngs: nnx.Rngs):
+    self.conv1 = nnx.Conv(1, 32, kernel_size=(3, 3), rngs=rngs)
+    self.conv2 = nnx.Conv(32, 64, kernel_size=(3, 3), rngs=rngs)
+    self.avg_pool = partial(nnx.avg_pool, window_shape=(2, 2), strides=(2, 2))
+    self.linear1 = nnx.Linear(3136, 256, rngs=rngs)
+    self.linear2 = nnx.Linear(256, 10, rngs=rngs)
+
+  def __call__(self, x):
+    x = self.avg_pool(nnx.relu(self.conv1(x)))
+    x = self.avg_pool(nnx.relu(self.conv2(x)))
+    x = x.reshape(x.shape[0], -1)  # flatten
+    x = nnx.relu(self.linear1(x))
+    x = self.linear2(x)
+    return x
+
+# Instantiate the model.
+model = CNN(rngs=nnx.Rngs(0))
+# Visualize it.
+#nnx.display(model)
+
+
+learning_rate = 0.005
+momentum = 0.9
+
+optimizer = nnx.Optimizer(model, optax.adamw(learning_rate, momentum))
+metrics = nnx.MultiMetric(
+  accuracy=nnx.metrics.Accuracy(),
+  loss=nnx.metrics.Average('loss'),
+)
+
+
+def loss_fn(model: CNN, batch):
+  logits = model(batch['image'])
+  loss = optax.softmax_cross_entropy_with_integer_labels(
+    logits=logits, labels=batch['label']
+  ).mean()
+  return loss, logits
+
+@nnx.jit
+def train_step(model: CNN, optimizer: nnx.Optimizer, metrics: nnx.MultiMetric, batch):
+  """Train for a single step."""
+  grad_fn = nnx.value_and_grad(loss_fn, has_aux=True)
+  (loss, logits), grads = grad_fn(model, batch)
+  metrics.update(loss=loss, logits=logits, labels=batch['label'])  # In-place updates.
+  optimizer.update(grads)  # In-place updates.
+
+@nnx.jit
+def eval_step(model: CNN, metrics: nnx.MultiMetric, batch):
+  loss, logits = loss_fn(model, batch)
+  metrics.update(loss=loss, logits=logits, labels=batch['label'])  # In-place updates.
+
+metrics_history = {
+  'train_loss': [],
+  'train_accuracy': [],
+  'test_loss': [],
+  'test_accuracy': [],
+}
+
+for step, batch in enumerate(train_ds.as_numpy_iterator()):
+  # Run the optimization for one step and make a stateful update to the following:
+  # - The train state's model parameters
+  # - The optimizer state
+  # - The training loss and accuracy batch metrics
+  loss, batch_accuracy = train_step(model, optimizer, metrics, batch)
+
+  # Print the training loss and accuracy every 100 steps.
+  if step % 100 == 0:
+    print("Step {}: Training Loss: {:.4f}, Batch Accuracy: {:.2f}%".format(
+        step, loss, batch_accuracy * 100))
+
+  # Evaluate and log metrics every 'eval_every' steps or at the last step.
+  if step > 0 and (step % eval_every == 0 or step == train_steps - 1):
+    # Log training metrics.
+    train_metrics = metrics.compute()
+    metrics_history['train_loss'].append(train_metrics['loss'])
+    metrics_history['train_accuracy'].append(train_metrics['accuracy'])
+    metrics.reset()
+
+    # Evaluate on the test set.
+    for test_batch in test_ds.as_numpy_iterator():
+        eval_step(model, metrics, test_batch)
+    test_metrics = metrics.compute()
+    metrics_history['test_loss'].append(test_metrics['loss'])
+    metrics_history['test_accuracy'].append(test_metrics['accuracy'])
+    metrics.reset()

--- a/dl-container/GPU/keras_jax.py
+++ b/dl-container/GPU/keras_jax.py
@@ -1,0 +1,93 @@
+import os
+
+# This guide can only be run with the jax backend.
+os.environ["KERAS_BACKEND"] = "jax"
+
+import jax
+
+# We import TF so we can use tf.data.
+import tensorflow as tf
+import keras
+import numpy as np
+
+def get_model():
+    inputs = keras.Input(shape=(784,), name="digits")
+    x1 = keras.layers.Dense(64, activation="relu")(inputs)
+    x2 = keras.layers.Dense(64, activation="relu")(x1)
+    outputs = keras.layers.Dense(10, name="predictions")(x2)
+    model = keras.Model(inputs=inputs, outputs=outputs)
+    return model
+
+
+model = get_model()
+
+# Prepare the training dataset.
+batch_size = 32
+(x_train, y_train), (x_test, y_test) = keras.datasets.mnist.load_data()
+x_train = np.reshape(x_train, (-1, 784)).astype("float32")
+x_test = np.reshape(x_test, (-1, 784)).astype("float32")
+y_train = keras.utils.to_categorical(y_train)
+y_test = keras.utils.to_categorical(y_test)
+
+# Reserve 10,000 samples for validation.
+x_val = x_train[-10000:]
+y_val = y_train[-10000:]
+x_train = x_train[:-10000]
+y_train = y_train[:-10000]
+
+# Prepare the training dataset.
+train_dataset = tf.data.Dataset.from_tensor_slices((x_train, y_train))
+train_dataset = train_dataset.shuffle(buffer_size=1024).batch(batch_size)
+
+# Prepare the validation dataset.
+val_dataset = tf.data.Dataset.from_tensor_slices((x_val, y_val))
+val_dataset = val_dataset.batch(batch_size)
+
+# Instantiate a loss function.
+loss_fn = keras.losses.CategoricalCrossentropy(from_logits=True)
+
+# Instantiate an optimizer.
+optimizer = keras.optimizers.Adam(learning_rate=1e-3)
+
+def compute_loss_and_updates(trainable_variables, non_trainable_variables, x, y):
+    y_pred, non_trainable_variables = model.stateless_call(
+        trainable_variables, non_trainable_variables, x, training=True
+    )
+    loss = loss_fn(y, y_pred)
+    return loss, non_trainable_variables
+
+grad_fn = jax.value_and_grad(compute_loss_and_updates, has_aux=True)
+
+@jax.jit
+def train_step(state, data):
+    trainable_variables, non_trainable_variables, optimizer_variables = state
+    x, y = data
+    (loss, non_trainable_variables), grads = grad_fn(
+        trainable_variables, non_trainable_variables, x, y
+    )
+    trainable_variables, optimizer_variables = optimizer.stateless_apply(
+        optimizer_variables, grads, trainable_variables
+    )
+    # Return updated state
+    return loss, (
+        trainable_variables,
+        non_trainable_variables,
+        optimizer_variables,
+    )
+
+# Build optimizer variables.
+optimizer.build(model.trainable_variables)
+
+trainable_variables = model.trainable_variables
+non_trainable_variables = model.non_trainable_variables
+optimizer_variables = optimizer.variables
+state = trainable_variables, non_trainable_variables, optimizer_variables
+
+# Training loop
+for step, data in enumerate(train_dataset):
+    data = (data[0].numpy(), data[1].numpy())
+    loss, state = train_step(state, data)
+    # Log every 100 batches.
+    if step % 100 == 0:
+        print(f"Training loss (for 1 batch) at step {step}: {float(loss):.4f}")
+        print(f"Seen so far: {(step + 1) * batch_size} samples")


### PR DESCRIPTION
## Summary by Sourcery

Add a GPU-enabled CI smoke test pipeline and strengthen GPU validation in the container.

New Features:
- Introduce a GPU smoke test script that validates CUDA availability and basic tensor and matmul operations for PyTorch, JAX, and TensorFlow.
- Add example JAX/Flax and Keras-on-JAX MNIST training scripts to the GPU container for experimentation and validation.

Enhancements:
- Improve GPU test logging and robustness by reporting library and device details and using stricter numerical assertions.
- Update the Python shebang in the GPU test script to use the environment’s default Python interpreter.

CI:
- Add a GitHub Actions workflow that builds the GPU Docker image for pull requests and runs the GPU smoke test in CI as a gate.